### PR TITLE
Fixed off-by-one commit bug, adding initial implementation of patch parser

### DIFF
--- a/src/interfaces/GitHubTypes.ts
+++ b/src/interfaces/GitHubTypes.ts
@@ -2,6 +2,7 @@ export interface FileInfo {
     name: string,
     additions: number,
     deletions: number,
+    diff: PatchInfo,
 }
 
 export interface CommitInfo {
@@ -12,4 +13,10 @@ export interface CommitInfo {
     additions: number,
     deletions: number,
     filesChanged: Array<FileInfo>
+}
+
+export interface PatchInfo {
+    name: string,
+    linesAdded: string[],
+    linesDeleted: string[],
 }

--- a/src/services/GithubService.ts
+++ b/src/services/GithubService.ts
@@ -43,11 +43,16 @@ export default class GithubService {
     }
 
     private async getMoreCommits(retrievedCommits: Array<CommitInfo>, repoUrl: string): Promise<Array<CommitInfo>> {
+        const offsetDateByMinute = (latestCommitTime) => {
+            return new Date(new Date(latestCommitTime).getTime() - 60000).toISOString();
+        };
+
         let dateUpTo: string;
         if (retrievedCommits.length === 0) {
             dateUpTo = new Date().toISOString();
         } else {
-            dateUpTo = retrievedCommits[retrievedCommits.length - 1].date;
+            const latestCommitTime = retrievedCommits[retrievedCommits.length - 1].date;
+            dateUpTo = offsetDateByMinute(latestCommitTime);
         }
         const requestUrl = this.urlBuilder.buildListCommitsUrl(repoUrl, dateUpTo);
         const rawCommits = await this.restClient.get(requestUrl);

--- a/src/services/PatchParser.ts
+++ b/src/services/PatchParser.ts
@@ -1,0 +1,31 @@
+import {PatchInfo} from "../interfaces/GitHubTypes";
+
+export default class PatchParser {
+
+    private readonly DELIMITER = "\n";
+
+    public extractPatchInfo(name: string, filePatch: string): PatchInfo {
+        let linesAdded: string[] = [];
+        let linesDeleted: string[] = [];
+        if (filePatch !== undefined) {
+            const patchLines: string[] = filePatch.split(this.DELIMITER).filter((line: string) => line.length > 0);
+            patchLines.forEach((line: string) => {
+                return this.populateChangedLineArrays(line, linesAdded, linesDeleted);
+            });
+            return { name: name, linesAdded: linesAdded, linesDeleted: linesDeleted } as PatchInfo;
+        }
+        return {} as PatchInfo;
+    }
+
+    private populateChangedLineArrays(line: string, linesAdded: string[], linesDeleted: string[]) {
+        if (this.isAddition(line)) {
+            return linesAdded.push(line.replace(/[ +]/g, ''));
+        } else {
+            return linesDeleted.push(line.replace(/[ -]/g, ''));
+        }
+    }
+
+    private isAddition(loc: string): boolean {
+        return loc[0] === "+";
+    }
+}

--- a/src/services/ResponseParser.ts
+++ b/src/services/ResponseParser.ts
@@ -1,6 +1,13 @@
 import {CommitInfo, FileInfo} from "../interfaces/GitHubTypes";
+import PatchParser from "./PatchParser";
 
 export default class ResponseParser {
+
+    private readonly patchParser: PatchParser;
+
+    constructor() {
+        this.patchParser = new PatchParser();
+    }
 
     public buildCommitMap(rawCommitData: Array<any>): Array<CommitInfo> {
         return rawCommitData.map((rawCommit) => {
@@ -30,6 +37,7 @@ export default class ResponseParser {
                 name: fileInfo["filename"],
                 additions: fileInfo["additions"],
                 deletions: fileInfo["deletions"],
+                diff: this.patchParser.extractPatchInfo(fileInfo["filename"], fileInfo["patch"]),
             } as FileInfo
         });
     }

--- a/test/services/GithubService.spec.ts
+++ b/test/services/GithubService.spec.ts
@@ -19,7 +19,6 @@ describe("GithubService tests", () => {
         } catch (err) {
             totalNumCommits = err;
         } finally {
-            // TODO: gets us back 160, off by one...
             expect(totalNumCommits.length).to.equal(159);
         }
     });


### PR DESCRIPTION
**What's new?**

* fixed the off-by-one error we had with getting commits from GitHub
* adding scaffolding for the parsing we'll need to do with the commits we get back from GitHub. 

@scveloso take a look!