### PR TITLE
Populate commit SHAs each method has been changed in

### DIFF
--- a/src/interfaces/GitHubTypes.ts
+++ b/src/interfaces/GitHubTypes.ts
@@ -19,4 +19,12 @@ export interface PatchInfo {
     name: string,
     linesAdded: string[],
     linesDeleted: string[],
+    diffHunks: DiffHunk[]
+}
+
+// Has the start and end line numbers of a new file
+// for each diff hunk
+export interface DiffHunk {
+    start: number,
+    end: number
 }

--- a/src/interfaces/Method.ts
+++ b/src/interfaces/Method.ts
@@ -4,10 +4,12 @@ export class Method {
     startLine: number;
     endLine: number;
     returnType: string;
-    commitsChangedIn: string[];
+    file: string; // which file this method is in
+    commitsChangedIn: string[]; // previous commits this method was changed in
 
-    constructor(name, startLine, endLine, returnType) {
+    constructor(name, file, startLine, endLine, returnType) {
         this.name = name;
+        this.file = file;
         this.startLine = startLine;
         this.endLine = endLine;
         this.returnType = returnType;
@@ -16,5 +18,9 @@ export class Method {
 
     addCommitChangedIn(commitSha: string) {
         this.commitsChangedIn.push(commitSha);
+    }
+
+    getIdentifier(): string {
+        return `${this.file}/${this.name}`;
     }
 }

--- a/src/interfaces/Method.ts
+++ b/src/interfaces/Method.ts
@@ -1,10 +1,12 @@
+/**
+ * Represents a Java method and its properties.
+ */
 export class Method {
-    // TODO: May need to have return types, and path to distinguish difference between multiple methods
     name: string;
     startLine: number;
     endLine: number;
     returnType: string;
-    file: string; // which file this method is in
+    file: string; // which file path this method is in
     commitsChangedIn: string[]; // previous commits this method was changed in
 
     constructor(name, file, startLine, endLine, returnType) {
@@ -16,10 +18,20 @@ export class Method {
         this.commitsChangedIn = [];
     }
 
+    /**
+     * Adds the given commit sha to the collection of commits this method has been changed in
+     *
+     * @param commitSha the sha of the commit this method was changed in
+     */
     addCommitChangedIn(commitSha: string) {
         this.commitsChangedIn.push(commitSha);
     }
 
+    /**
+     * Returns an identifier as the combination of the file path to this method and the method name
+     *
+     * Used to distinguish methods as well as maintain a dictionary of methods for efficient method updating
+     */
     getIdentifier(): string {
         return `${this.file}/${this.name}`;
     }

--- a/src/interfaces/Method.ts
+++ b/src/interfaces/Method.ts
@@ -4,11 +4,17 @@ export class Method {
     startLine: number;
     endLine: number;
     returnType: string;
+    commitsChangedIn: string[];
 
     constructor(name, startLine, endLine, returnType) {
         this.name = name;
         this.startLine = startLine;
         this.endLine = endLine;
         this.returnType = returnType;
+        this.commitsChangedIn = [];
+    }
+
+    addCommitChangedIn(commitSha: string) {
+        this.commitsChangedIn.push(commitSha);
     }
 }

--- a/src/services/GithubService.ts
+++ b/src/services/GithubService.ts
@@ -17,7 +17,7 @@ export default class GithubService {
 
     constructor(restClient: IRestClient, cache: ICommitCache) {
         this.restClient = restClient;
-        this.urlBuilder = new URLBuilder( "NOPE");
+        this.urlBuilder = new URLBuilder( "");
         this.responseParser = new ResponseParser();
         this.cache = cache;
     }

--- a/src/services/MethodDependencyBuilder.ts
+++ b/src/services/MethodDependencyBuilder.ts
@@ -37,9 +37,6 @@ export default class MethodDependencyBuilder {
         let headMethods = await this.getAllMethodsAtCommitShaOfRepo(repoUrl, repoName, HEAD);
         let headMethodsMap = this.buildMethodMap(headMethods);
 
-        //commitMethodMap[HEAD] = this.buildMethodMap(commitMethodMap[HEAD]);
-        //allCommits.shift(); // remove HEAD
-
         // Get rest of the commits' methods and whether they were changed in this method
         for (let commit of allCommits) {
             let commitMethods = await this.getAllMethodsAtCommitShaOfRepo(repoUrl, repoName, commit.sha);

--- a/src/services/MethodDependencyBuilder.ts
+++ b/src/services/MethodDependencyBuilder.ts
@@ -5,6 +5,9 @@ import GitCommitCache from "./GitCommitCache";
 import RestClient from "../rest/RestClient";
 import {CommitInfo, FileInfo} from "../interfaces/GitHubTypes";
 
+/**
+ * A class to build cross-cut dependencies (across previous commits) between methods of HEAD.
+ */
 export default class MethodDependencyBuilder {
     methodParser: MethodParser;
     ghService: GithubService;
@@ -18,19 +21,24 @@ export default class MethodDependencyBuilder {
         this.ghService = new GithubService(this.liveRestClient, this.liveCache);
     }
 
+    /**
+     * Return cross-cut dependencies between methods of HEAD at the given repoUrl
+     *
+     * @param repoUrl the repository to build method cross-cut dependencies
+     */
     public async execute(repoUrl: string) {
         let splitUrl = repoUrl.split("/");
         let repoName: string = splitUrl[splitUrl.length - 1];
 
-        // All methods for each commit
-        let commitMethodMap = {};
         let allCommits: CommitInfo[] = await this.ghService.getAndSaveAllCommits(repoUrl);
         let HEAD = allCommits[0].sha;
 
         // Get all methods for HEAD
-        commitMethodMap[HEAD] = await this.getAllMethodsAtCommitShaOfRepo(repoUrl, repoName, HEAD);
-        commitMethodMap[HEAD] = this.buildMethodMap(commitMethodMap[HEAD]);
-        allCommits.shift(); // remove HEAD
+        let headMethods = await this.getAllMethodsAtCommitShaOfRepo(repoUrl, repoName, HEAD);
+        let headMethodsMap = this.buildMethodMap(headMethods);
+
+        //commitMethodMap[HEAD] = this.buildMethodMap(commitMethodMap[HEAD]);
+        //allCommits.shift(); // remove HEAD
 
         // Get rest of the commits' methods and whether they were changed in this method
         for (let commit of allCommits) {
@@ -38,17 +46,24 @@ export default class MethodDependencyBuilder {
 
             for (let method of commitMethods) {
                 if (this.isMethodChangedInCommit(method, commit)) {
-                    if (commitMethodMap[HEAD][method.getIdentifier()] !== undefined) {
-                        commitMethodMap[HEAD][method.getIdentifier()].addCommitChangedIn(commit.sha);
-                        console.log("method name: " + method.getIdentifier() + " changed in  " + commit.sha);
+                    if (headMethodsMap[method.getIdentifier()] !== undefined) {
+                        headMethodsMap[method.getIdentifier()].addCommitChangedIn(commit.sha);
                     }
                 }
             }
-
-            commitMethodMap[commit.sha] = commitMethods;
         }
+
+        return headMethodsMap;
     }
 
+    /**
+     * Builds a method dictionary from a given array of Methods
+     *
+     * Allows us to update methods based on which commits they have been
+     * changed in O(1) time.
+     *
+     * @param methods the methods to build a dictionary out of
+     */
     private buildMethodMap(methods: Method[]) {
         let methodMap = {};
         for (let method of methods) {
@@ -58,15 +73,23 @@ export default class MethodDependencyBuilder {
         return methodMap;
     }
 
-    public isMethodChangedInCommit(method: Method, commit: CommitInfo): boolean {
+    /**
+     * Returns true if the given Method was changed in the given commit
+     *
+     * @param method the given Method
+     * @param commit the commit to check if the method has been changed in
+     */
+    private isMethodChangedInCommit(method: Method, commit: CommitInfo): boolean {
         for (let fileChanged of commit.filesChanged) {
             if (this.methodInFileAndHasDiffs(fileChanged, method)) {
                 let methodChanged = false;
                 fileChanged.diff.diffHunks.forEach((diffHunk) => {
-                    if ((diffHunk.start >= method.startLine &&
+                    if ((diffHunk.start >= method.startLine &&  // 1) Hunk start is contained within method
                         diffHunk.start <= method.endLine) ||
-                        (diffHunk.end >= method.startLine &&
-                            diffHunk.end <= method.endLine)) {
+                        (diffHunk.end >= method.startLine &&    // 2) Hunk end is contained within method
+                            diffHunk.end <= method.endLine) ||
+                        (diffHunk.start <= method.startLine &&  // 3) Method is contained within hunk
+                        diffHunk.end >= method.endLine)) {
                         methodChanged = true;
                         return;
                     }
@@ -81,12 +104,27 @@ export default class MethodDependencyBuilder {
         return false;
     }
 
+    /**
+     * Returns true if the given Method is contained in the file, and
+     * if the file has valid diff and diff hunks
+     *
+     * @param fileChanged the file to check
+     * @param method to check in the file
+     */
     private methodInFileAndHasDiffs(fileChanged: FileInfo, method: Method): boolean {
         return fileChanged.name === method.file && fileChanged.diff !== undefined &&
             fileChanged.diff.diffHunks !== undefined;
     }
 
-    public async getAllMethodsAtCommitShaOfRepo(repoUrl: string, repoName: string, commitSha?: string) {
+    /**
+     * Returns all the methods at a given repo and commit sha using MethodParser
+     * and GithubService
+     *
+     * @param repoUrl the URL of the repository to check
+     * @param repoName name of the repository
+     * @param commitSha the commit to get the methods at
+     */
+    private async getAllMethodsAtCommitShaOfRepo(repoUrl: string, repoName: string, commitSha?: string) {
         let methods: Method[];
 
         await this.ghService.getAndSaveRepo(repoUrl, commitSha);

--- a/src/services/MethodDependencyBuilder.ts
+++ b/src/services/MethodDependencyBuilder.ts
@@ -4,6 +4,7 @@ import {Method} from "../interfaces/Method";
 import GitCommitCache from "./GitCommitCache";
 import RestClient from "../rest/RestClient";
 import {CommitInfo, FileInfo} from "../interfaces/GitHubTypes";
+import * as fs from "fs-extra";
 
 /**
  * A class to build cross-cut dependencies (across previous commits) between methods of HEAD.
@@ -124,8 +125,13 @@ export default class MethodDependencyBuilder {
     private async getAllMethodsAtCommitShaOfRepo(repoUrl: string, repoName: string, commitSha?: string) {
         let methods: Method[];
 
-        await this.ghService.getAndSaveRepo(repoUrl, commitSha);
-        methods = await this.methodParser.getMethodsFromProject("./data/", repoName, commitSha);
+        try {
+            await this.ghService.getAndSaveRepo(repoUrl, commitSha);
+            methods = await this.methodParser.getMethodsFromProject("./data/", repoName, commitSha);
+        } catch (err) {
+            console.log(`MethodDependencyBuilder::failed to get methods from repo: ${repoName}`);
+            throw err;
+        }
 
         return methods;
     }

--- a/src/services/MethodDependencyBuilder.ts
+++ b/src/services/MethodDependencyBuilder.ts
@@ -1,0 +1,39 @@
+import MethodParser from "./MethodParser";
+import GithubService from "./GithubService";
+import {Method} from "../interfaces/Method";
+import GitCommitCache from "./GitCommitCache";
+import RestClient from "../rest/RestClient";
+
+export default class MethodDependencyBuilder {
+    methodParser: MethodParser;
+    ghService: GithubService;
+    liveRestClient: RestClient;
+    liveCache: GitCommitCache;
+
+    constructor() {
+        this.methodParser = new MethodParser();
+        this.liveRestClient = new RestClient();
+        this.liveCache = new GitCommitCache();
+        this.ghService = new GithubService(this.liveRestClient, this.liveCache);
+    }
+
+    public async execute(repoUrl: string) {
+        let splitUrl = repoUrl.split("/");
+        let repoName: string = splitUrl[splitUrl.length - 1];
+        // 1) Get the methods at commit HEAD
+        let methodsAtHead = await this.getAllMethodsAtHeadOfRepo(repoUrl, repoName);
+
+        // 2) For every commit C earlier than HEAD
+        let allCommits = await this.ghService.getAndSaveAllCommits(repoUrl);
+        console.log(allCommits);
+    }
+
+    public async getAllMethodsAtHeadOfRepo(repoUrl: string, repoName: string) {
+        let methods: Method[];
+
+        await this.ghService.getAndSaveRepo(repoUrl);
+        methods = await this.methodParser.getMethodsFromProject("./data/", repoName);
+
+        return methods;
+    }
+}

--- a/src/services/MethodDependencyBuilder.ts
+++ b/src/services/MethodDependencyBuilder.ts
@@ -3,6 +3,7 @@ import GithubService from "./GithubService";
 import {Method} from "../interfaces/Method";
 import GitCommitCache from "./GitCommitCache";
 import RestClient from "../rest/RestClient";
+import {CommitInfo, FileInfo} from "../interfaces/GitHubTypes";
 
 export default class MethodDependencyBuilder {
     methodParser: MethodParser;
@@ -20,19 +21,76 @@ export default class MethodDependencyBuilder {
     public async execute(repoUrl: string) {
         let splitUrl = repoUrl.split("/");
         let repoName: string = splitUrl[splitUrl.length - 1];
-        // 1) Get the methods at commit HEAD
-        let methodsAtHead = await this.getAllMethodsAtHeadOfRepo(repoUrl, repoName);
 
-        // 2) For every commit C earlier than HEAD
-        let allCommits = await this.ghService.getAndSaveAllCommits(repoUrl);
-        console.log(allCommits);
+        // All methods for each commit
+        let commitMethodMap = {};
+        let allCommits: CommitInfo[] = await this.ghService.getAndSaveAllCommits(repoUrl);
+        let HEAD = allCommits[0].sha;
+
+        // Get all methods for HEAD
+        commitMethodMap[HEAD] = await this.getAllMethodsAtCommitShaOfRepo(repoUrl, repoName, HEAD);
+        commitMethodMap[HEAD] = this.buildMethodMap(commitMethodMap[HEAD]);
+        allCommits.shift(); // remove HEAD
+
+        // Get rest of the commits' methods and whether they were changed in this method
+        for (let commit of allCommits) {
+            let commitMethods = await this.getAllMethodsAtCommitShaOfRepo(repoUrl, repoName, commit.sha);
+
+            for (let method of commitMethods) {
+                if (this.isMethodChangedInCommit(method, commit)) {
+                    if (commitMethodMap[HEAD][method.getIdentifier()] !== undefined) {
+                        commitMethodMap[HEAD][method.getIdentifier()].addCommitChangedIn(commit.sha);
+                        console.log("method name: " + method.getIdentifier() + " changed in  " + commit.sha);
+                    }
+                }
+            }
+
+            commitMethodMap[commit.sha] = commitMethods;
+        }
     }
 
-    public async getAllMethodsAtHeadOfRepo(repoUrl: string, repoName: string) {
+    private buildMethodMap(methods: Method[]) {
+        let methodMap = {};
+        for (let method of methods) {
+            methodMap[method.getIdentifier()] = method;
+        }
+
+        return methodMap;
+    }
+
+    public isMethodChangedInCommit(method: Method, commit: CommitInfo): boolean {
+        for (let fileChanged of commit.filesChanged) {
+            if (this.methodInFileAndHasDiffs(fileChanged, method)) {
+                let methodChanged = false;
+                fileChanged.diff.diffHunks.forEach((diffHunk) => {
+                    if ((diffHunk.start >= method.startLine &&
+                        diffHunk.start <= method.endLine) ||
+                        (diffHunk.end >= method.startLine &&
+                            diffHunk.end <= method.endLine)) {
+                        methodChanged = true;
+                        return;
+                    }
+                });
+
+                if (methodChanged) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private methodInFileAndHasDiffs(fileChanged: FileInfo, method: Method): boolean {
+        return fileChanged.name === method.file && fileChanged.diff !== undefined &&
+            fileChanged.diff.diffHunks !== undefined;
+    }
+
+    public async getAllMethodsAtCommitShaOfRepo(repoUrl: string, repoName: string, commitSha?: string) {
         let methods: Method[];
 
-        await this.ghService.getAndSaveRepo(repoUrl);
-        methods = await this.methodParser.getMethodsFromProject("./data/", repoName);
+        await this.ghService.getAndSaveRepo(repoUrl, commitSha);
+        methods = await this.methodParser.getMethodsFromProject("./data/", repoName, commitSha);
 
         return methods;
     }

--- a/src/services/MethodParser.ts
+++ b/src/services/MethodParser.ts
@@ -14,14 +14,19 @@ export default class MethodParser {
      *
      * @param dir the directory to the repo file
      * @param repoName the name of the repository
+     * @param commitSha the commit we want to get the repo file of
      */
-    public async getMethodsFromProject(dir, repoName): Promise<Method[]> {
+    public async getMethodsFromProject(dir, repoName, commitSha?): Promise<Method[]> {
         let repoObject;
         let allMethods: Method[] = [];
 
+        if (commitSha !== undefined) {
+            repoName = `${repoName}--${commitSha}`;
+        }
+
         repoObject = await this.fileSystem.readRepoFromDisk(dir, repoName);
         for (let fileName in repoObject) {
-            allMethods = allMethods.concat(this.getMethodsFromJavaFile(repoObject[fileName]));
+            allMethods = allMethods.concat(this.getMethodsFromJavaFile(repoObject[fileName], fileName));
         }
 
         return allMethods;
@@ -31,8 +36,9 @@ export default class MethodParser {
      * Returns all the Java Methods in the given Java file
      *
      * @param javaFileString the Java file, in string form
+     * @param fileName which file we are getting methods from
      */
-    public getMethodsFromJavaFile(javaFileString): Method[] {
+    public getMethodsFromJavaFile(javaFileString, fileName): Method[] {
         let javaFileStringArr = javaFileString.split("\n");
 
         let regexp = RegExp("^(\\t|    )(public|private)( )(static )?([\\w\\d<>]* )+[\\w\\d_.-]+((\\((( )*[\\w\\d\\[\\]<>,_.-]+ [\\w\\d_.-]+,?)*\\))) {$");
@@ -44,7 +50,7 @@ export default class MethodParser {
         for (let line of javaFileStringArr) {
             // Found a method!
             if (regexp.test(line)) {
-                methods.push(this.parseMethodSignature(line, lineNumber));
+                methods.push(this.parseMethodSignature(line, lineNumber, fileName));
             }
 
             // Found the end of the latest method found, update its endLine
@@ -63,8 +69,9 @@ export default class MethodParser {
      *
      * @param methodSignature the method signature to parse
      * @param startLine the line number this method begins in
+     * @param fileName which file this method was found in
      */
-    public parseMethodSignature(methodSignature: string, startLine: number): Method {
+    public parseMethodSignature(methodSignature: string, startLine: number, fileName: string): Method {
         let tokens = methodSignature.split(" ");
         let index = 0;
         let tabLevel: number = 0;
@@ -107,6 +114,6 @@ export default class MethodParser {
             index++
         }
 
-        return new Method(methodName, startLine, 0, returnType);
+        return new Method(methodName, fileName, startLine, 0, returnType);
     }
 }

--- a/src/services/MethodParser.ts
+++ b/src/services/MethodParser.ts
@@ -1,6 +1,9 @@
 import {Method} from "../interfaces/Method";
 import FileSystem from "../util/FileSystem";
 
+/**
+ * A class to extract all the methods from a given repository and commit sha.
+ */
 export default class MethodParser {
 
     private readonly fileSystem: FileSystem;

--- a/src/services/PatchParser.ts
+++ b/src/services/PatchParser.ts
@@ -1,4 +1,4 @@
-import {PatchInfo} from "../interfaces/GitHubTypes";
+import {DiffHunk, PatchInfo} from "../interfaces/GitHubTypes";
 
 export default class PatchParser {
 
@@ -7,21 +7,27 @@ export default class PatchParser {
     public extractPatchInfo(name: string, filePatch: string): PatchInfo {
         let linesAdded: string[] = [];
         let linesDeleted: string[] = [];
+        let diffHunks: DiffHunk[] = [];
         if (filePatch !== undefined) {
             const patchLines: string[] = filePatch.split(this.DELIMITER).filter((line: string) => line.length > 0);
             patchLines.forEach((line: string) => {
-                return this.populateChangedLineArrays(line, linesAdded, linesDeleted);
+                return this.populateChangedLineArrays(line, linesAdded, linesDeleted, diffHunks);
             });
-            return { name: name, linesAdded: linesAdded, linesDeleted: linesDeleted } as PatchInfo;
+            return { name: name, linesAdded: linesAdded, linesDeleted: linesDeleted, diffHunks: diffHunks } as PatchInfo;
         }
         return {} as PatchInfo;
     }
 
-    private populateChangedLineArrays(line: string, linesAdded: string[], linesDeleted: string[]) {
+    private populateChangedLineArrays(line: string,
+                                      linesAdded: string[],
+                                      linesDeleted: string[],
+                                      diffHunks: DiffHunk[]) {
         if (this.isAddition(line)) {
             return linesAdded.push(line.replace(/[ +]/g, ''));
         } else if (this.isDeletion(line)) {
             return linesDeleted.push(line.replace(/[ -]/g, ''));
+        } else if (this.isDiffMarker(line)) {
+            return diffHunks.push(this.extractDiffHunkFromLine(line));
         }
     }
 
@@ -31,5 +37,18 @@ export default class PatchParser {
 
     private isDeletion(loc: string): boolean {
         return loc[0] === "-";
+    }
+
+    private isDiffMarker(loc: string): boolean {
+        return loc.substr(0, 2) === "@@";
+    }
+
+    private extractDiffHunkFromLine(line: string): DiffHunk {
+        let lineArr = line.split(" ");
+        let newFileLineNumbers = lineArr[2].split(",");
+        let start = +newFileLineNumbers[0];
+        let numLinesChanged = +newFileLineNumbers[1];
+
+        return { start: start, end: (start + numLinesChanged) } as DiffHunk;
     }
 }

--- a/src/util/FileSystem.ts
+++ b/src/util/FileSystem.ts
@@ -82,8 +82,13 @@ export default class FileSystem {
         return !content.dir && content.name.includes(".java");
     }
 
+    // private getFileName(fullPath: string): string {
+    //     const lastSlashIndex: number = fullPath.lastIndexOf("/");
+    //     return fullPath.substring(lastSlashIndex + 1);
+    // }
+
     private getFileName(fullPath: string): string {
-        const lastSlashIndex: number = fullPath.lastIndexOf("/");
-        return fullPath.substring(lastSlashIndex + 1);
+        const firstSlashIndex: number = fullPath.indexOf("/");
+        return fullPath.substring(firstSlashIndex + 1);
     }
 }

--- a/src/util/FileSystem.ts
+++ b/src/util/FileSystem.ts
@@ -82,11 +82,6 @@ export default class FileSystem {
         return !content.dir && content.name.includes(".java");
     }
 
-    // private getFileName(fullPath: string): string {
-    //     const lastSlashIndex: number = fullPath.lastIndexOf("/");
-    //     return fullPath.substring(lastSlashIndex + 1);
-    // }
-
     private getFileName(fullPath: string): string {
         const firstSlashIndex: number = fullPath.indexOf("/");
         return fullPath.substring(firstSlashIndex + 1);

--- a/src/util/FileSystem.ts
+++ b/src/util/FileSystem.ts
@@ -11,7 +11,10 @@ export default class FileSystem {
     public async write(dir: string, fileName: string, content: string): Promise<string> {
         const fullPath: string = `${dir}/${fileName}`;
         try {
-            await fs.mkdir(dir);
+            if (!fs.existsSync(dir)) {
+                await fs.mkdir(dir);
+            }
+
             await fs.writeFile(fullPath, content);
             return fullPath;
         } catch (err) {

--- a/test/services/MethodDependencyBuilder.spec.ts
+++ b/test/services/MethodDependencyBuilder.spec.ts
@@ -1,0 +1,11 @@
+import MethodDependencyBuilder from "../../src/services/MethodDependencyBuilder";
+
+describe("MethodParser tests", () => {
+
+    let mdb: MethodDependencyBuilder = new MethodDependencyBuilder();
+
+    it("should obtain the java-practice repo file and get all the methods from that repo file", async () => {
+        const sampleRepo: string = "https://github.com/jyoo980/java-practice";
+        await mdb.execute(sampleRepo);
+    });
+});

--- a/test/services/MethodDependencyBuilder.spec.ts
+++ b/test/services/MethodDependencyBuilder.spec.ts
@@ -5,6 +5,7 @@ describe("MethodParser tests", () => {
     let mdb: MethodDependencyBuilder = new MethodDependencyBuilder();
 
     it("should obtain the java-practice repo file and get all the methods from that repo file", async () => {
+        //const sampleRepo: string = "https://github.com/scveloso/DNS-Resolver";
         const sampleRepo: string = "https://github.com/jyoo980/java-practice";
         await mdb.execute(sampleRepo);
     });

--- a/test/services/MethodDependencyBuilder.spec.ts
+++ b/test/services/MethodDependencyBuilder.spec.ts
@@ -1,12 +1,28 @@
 import MethodDependencyBuilder from "../../src/services/MethodDependencyBuilder";
+import {expect} from "chai";
 
-describe("MethodParser tests", () => {
-
+describe("MethodDependencyBuilder tests", function () {
+    this.timeout(10000);
     let mdb: MethodDependencyBuilder = new MethodDependencyBuilder();
 
-    it("should obtain the java-practice repo file and get all the methods from that repo file", async () => {
-        //const sampleRepo: string = "https://github.com/scveloso/DNS-Resolver";
-        const sampleRepo: string = "https://github.com/jyoo980/java-practice";
-        await mdb.execute(sampleRepo);
+    it("a method that was changed in three commits should contain those three commits", async () => {
+        let getResultsMethod = "src/ca/ubc/cs/cs317/dnslookup/DNSLookupService.java/getResults";
+        let equalsMethod = "src/ca/ubc/cs/cs317/dnslookup/ResourceRecord.java/equals";
+        let getNameFromPointerMethod = "src/ca/ubc/cs/cs317/dnslookup/DNSLookupService.java/getNameFromPointerInBuffer";
+
+        const sampleRepo: string = "https://github.com/scveloso/DNS-Resolver";
+        let headMethodsMap = await mdb.execute(sampleRepo);
+
+        expect(headMethodsMap[getResultsMethod].commitsChangedIn.length).to.equal(3);
+        expect(headMethodsMap[getResultsMethod].commitsChangedIn).to.contain("3e6288124cce43a861603c331c9419531595f707");
+        expect(headMethodsMap[getResultsMethod].commitsChangedIn).to.contain("a7b4613e663d8d17d3146f345aede907255ee251");
+        expect(headMethodsMap[getResultsMethod].commitsChangedIn).to.contain("2fa370b3105af3d7105cc3c8eb7a5bec0c12cda0");
+
+        expect(headMethodsMap[equalsMethod].commitsChangedIn.length).to.equal(1);
+        expect(headMethodsMap[equalsMethod].commitsChangedIn).to.contain("2fa370b3105af3d7105cc3c8eb7a5bec0c12cda0");
+
+        expect(headMethodsMap[getNameFromPointerMethod].commitsChangedIn.length).to.equal(2);
+        expect(headMethodsMap[getNameFromPointerMethod].commitsChangedIn).to.contain("3e6288124cce43a861603c331c9419531595f707");
+        expect(headMethodsMap[getNameFromPointerMethod].commitsChangedIn).to.contain("a7b4613e663d8d17d3146f345aede907255ee251");
     });
 });

--- a/test/services/MethodParser.spec.ts
+++ b/test/services/MethodParser.spec.ts
@@ -5,8 +5,8 @@ import GitCommitCache from "../../src/services/GitCommitCache";
 import RestClient from "../../src/rest/RestClient";
 import {Method} from "../../src/interfaces/Method";
 
-describe("MethodParser tests", () => {
-
+describe("MethodParser tests", function () {
+    this.timeout(10000);
     let methodParser: MethodParser = new MethodParser();
     let liveRestClient: RestClient = new RestClient();
     let liveCache: GitCommitCache = new GitCommitCache();


### PR DESCRIPTION
Determining whether a method has been changed in a given commit is still rough and there's room for refinement, I look at the start and end line numbers of a method and compare them to diff hunks of the new file in previous commits. Its possible that a method is in the diff hunk but the method isn't actually changed so this is, at the worst case, an over-approximation of which commits the method was changed in.

## Done:
- Populating which commits a method at HEAD was changed in
- Tests for that

## To-do:
- Comparing these methods and which commits they've been changed in to each other and building the dependency matrix - which I'll leave to @uslava77 