### PR TITLE
fixing broken build badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-# it-depends ![build-status](https://gitlab.com/jamesyoo/it-depends/badges/master/build.svg)
+# it-depends ![build-status](https://gitlab.com/jamesyoo/it-depends/badges/master/pipeline.svg)
 
 ![viz-screenshot](./media/it-depends-viz.png)
 


### PR DESCRIPTION
**What's new?**

Pointing the build badge URL to one that works